### PR TITLE
Add systemd services and timers for cron tasks

### DIFF
--- a/systemd/peering-manager_configuration-deployment.service
+++ b/systemd/peering-manager_configuration-deployment.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Push configuration to routers
+
+[Service]
+Type=oneshot
+User=peering-manager
+Group=peering-manager
+WorkingDirectory=/opt/peering-manager
+ExecStart=/opt/peering-manager/venv/bin/python3 manage.py configure_routers

--- a/systemd/peering-manager_configuration-deployment.timer
+++ b/systemd/peering-manager_configuration-deployment.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Push router configuration every hour 5 minutes before full hour
+
+[Timer]
+OnCalendar=*:55:00
+
+[Install]
+WantedBy=timers.target

--- a/systemd/peering-manager_peeringdb-sync.service
+++ b/systemd/peering-manager_peeringdb-sync.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=PeeringDB sync
+
+[Service]
+Type=oneshot
+User=peering-manager
+Group=peering-manager
+WorkingDirectory=/opt/peering-manager
+ExecStart=/opt/peering-manager/venv/bin/python3 manage.py peeringdb_sync

--- a/systemd/peering-manager_peeringdb-sync.timer
+++ b/systemd/peering-manager_peeringdb-sync.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Sync PeeringDB at 2:30
+
+[Timer]
+OnCalendar=02:30:00
+
+[Install]
+WantedBy=timers.target

--- a/systemd/peering-manager_prefix-fetch.service
+++ b/systemd/peering-manager_prefix-fetch.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Fetch IRR AS-SET prefixes
+
+[Service]
+Type=oneshot
+User=peering-manager
+Group=peering-manager
+WorkingDirectory=/opt/peering-manager
+ExecStart=/opt/peering-manager/venv/bin/python3 manage.py grab_prefixes

--- a/systemd/peering-manager_prefix-fetch.timer
+++ b/systemd/peering-manager_prefix-fetch.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Fetch IRR AS-SET prefixes at 4:30
+
+[Timer]
+OnCalendar=04:30:00
+
+[Install]
+WantedBy=timers.target

--- a/systemd/peering-manager_session-poll.service
+++ b/systemd/peering-manager_session-poll.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Poll peering sessions from routers
+
+[Service]
+Type=oneshot
+User=peering-manager
+Group=peering-manager
+WorkingDirectory=/opt/peering-manager
+ExecStart=/opt/peering-manager/venv/bin/python3 manage.py poll_peering_sessions --all

--- a/systemd/peering-manager_session-poll.timer
+++ b/systemd/peering-manager_session-poll.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Poll peering sessions from routers every hour
+
+[Timer]
+OnCalendar=*:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The installation process already contains setting up Peering Manager with systemd services.
So I created systemd files to use instead of using crontab.

A second PR with updates for the documentation will follow soon.