### PR TITLE
Remove unrecognized argument

### DIFF
--- a/systemd/peering-manager_session-poll.service
+++ b/systemd/peering-manager_session-poll.service
@@ -6,4 +6,4 @@ Type=oneshot
 User=peering-manager
 Group=peering-manager
 WorkingDirectory=/opt/peering-manager
-ExecStart=/opt/peering-manager/venv/bin/python3 manage.py poll_bgp_sessions --all
+ExecStart=/opt/peering-manager/venv/bin/python3 manage.py poll_bgp_sessions


### PR DESCRIPTION
The "--all" argument was previously used when polling the status of BGP sessions on a router. This argument has been removed both in the script and in the documentation but not in the contributed systemd service file, making the service never execute successfully.

Removing the argument makes the script poll the BGP sessions without any errors.